### PR TITLE
feat: Allow 'docs:' as prefix for PR's

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -75,6 +75,21 @@ export class GemeenteNijmegenCdkApp extends awscdk.AwsCdkTypeScriptApp {
     };
 
     /**
+     * Set default github options (Adds docs: as acceptable prefix for PR linting)
+     */
+     options = {
+      githubOptions: {
+        pullRequestLintOptions: {
+          semanticTitleOptions: {
+            types: ['fix', 'feat', 'chore', 'docs'],
+          },
+        },
+      },
+      ...options,
+    };
+
+
+    /**
      * Set default gitignore
      */
     options = {

--- a/src/project.ts
+++ b/src/project.ts
@@ -77,7 +77,7 @@ export class GemeenteNijmegenCdkApp extends awscdk.AwsCdkTypeScriptApp {
     /**
      * Set default github options (Adds docs: as acceptable prefix for PR linting)
      */
-     options = {
+    options = {
       githubOptions: {
         pullRequestLintOptions: {
           semanticTitleOptions: {


### PR DESCRIPTION
The default projen settings only allow fix, feat and chore as PR prefixes. docs is also allowed in semantic release, and is useful for docs-only PR's. This adds `docs:` as a default prefix.