### PR TITLE
feat: Add automerge workflow (default on)

### DIFF
--- a/API.md
+++ b/API.md
@@ -168,6 +168,7 @@ const gemeenteNijmegenCdkAppOptions: GemeenteNijmegenCdkAppOptions = { ... }
 | <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.lambdaAutoDiscover">lambdaAutoDiscover</a></code> | <code>boolean</code> | Automatically adds an `awscdk.LambdaFunction` for each `.lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. |
 | <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.lambdaExtensionAutoDiscover">lambdaExtensionAutoDiscover</a></code> | <code>boolean</code> | Automatically adds an `awscdk.LambdaExtension` for each `.lambda-extension.ts` entrypoint in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. |
 | <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.lambdaOptions">lambdaOptions</a></code> | <code>projen.awscdk.LambdaFunctionCommonOptions</code> | Common options for all AWS Lambda functions. |
+| <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.enableAutoMergeDependencies">enableAutoMergeDependencies</a></code> | <code>boolean</code> | Enable an additional workflow that auto-merges PR's with the 'auto-merge' label. |
 | <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.enableCfnDiffWorkflow">enableCfnDiffWorkflow</a></code> | <code>boolean</code> | Enable CloudFormation template diff comments on PRs. |
 | <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.enableCfnLintOnGithub">enableCfnLintOnGithub</a></code> | <code>boolean</code> | Enable cfn-lint in the github build workflow. |
 | <code><a href="#@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
@@ -2314,6 +2315,22 @@ public readonly lambdaOptions: LambdaFunctionCommonOptions;
 - *Default:* default options
 
 Common options for all AWS Lambda functions.
+
+---
+
+##### `enableAutoMergeDependencies`<sup>Optional</sup> <a name="enableAutoMergeDependencies" id="@gemeentenijmegen/modules-projen.GemeenteNijmegenCdkAppOptions.property.enableAutoMergeDependencies"></a>
+
+```typescript
+public readonly enableAutoMergeDependencies: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Enable an additional workflow that auto-merges PR's with the 'auto-merge' label.
+
+NB: Auto-merge must be on in github settings, and branch protection
+with checks enabled is required to prevent merges of unsuccesful jobs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,24 @@ There are a number of relevant properties that are provided by projen
 
 
 The project type in this npm package provides some additional configuration options:
-| Property                 | Default | Explanation                                                                                 |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------- |
-| enableCfnLintOnGithub    | true    | Enable step in the Github build workflow that runs cfn-lint                                 |
-| enableCfnDiffWorkflow    | false   | Enable job in the Github build workflow that checks for changes in CloudFormation templates |
-| enableEmergencyProcedure | true    | Adds the emergency procedure workflow to Github workflows                                   |
+| Property                    | Default | Explanation                                                                                 |
+| --------------------------- | ------- | ------------------------------------------------------------------------------------------- |
+| enableCfnLintOnGithub       | true    | Enable step in the Github build workflow that runs cfn-lint                                 |
+| enableCfnDiffWorkflow       | false   | Enable job in the Github build workflow that checks for changes in CloudFormation templates |
+| enableEmergencyProcedure    | true    | Adds the emergency procedure workflow to Github workflows                                   |
+| enableAutoMergeDependencies | true    | Adds the auto-merge workflow for PR's to acceptance (from upgrade workflow)                 |
 
 
 ## Upgrade dependencies
 De upgrade dependencies task en Github workflow zijn standaard enabled. Deze task zal de laatste versies van de dependencies zoeken (volgens [semantic versionioning](https://semver.org/lang/nl/)) en upgraden in de `package.json`. 
 
 Dit project type zet de default branch voor het uitvoeren van de workflow op `acceptance`.
-De Github workflow voert de upgrade dependencies taak uit en maakt een PR naar `acceptance` en geeft het PR een label `cfn-diff`.
+De Github workflow voert de upgrade dependencies taak uit en maakt een PR naar `acceptance` en geeft het PR een label `cfn-diff` en `auto-merge`.
+
+### Automerge workflow
+De automerge workflow gaat af als een PR `acceptance` als base heeft en het label `auto-merge` heeft. Deze probeert het PR te mergen met de auto-merge
+feature van Github. Hiervoor moet in het Github-project automerge aan staan. **NB**: Zorg dat branch protection aan staat voor acceptance, met de eis dat aan
+alle voorwaarden voldaan is. Anders kan de auto-merge worden uitgevoerd voordat de build succesvol is.
 
 ### CDK upgrade
 De upgrade dependencies taak in projen is inclusief de CDK versie. Hiervoor wordt de minimum versie in de `.projenrc.js` van een project ingesteeld. 

--- a/src/mergejob.ts
+++ b/src/mergejob.ts
@@ -1,0 +1,45 @@
+import { Project } from 'projen';
+import { GitHub, GithubWorkflow } from 'projen/lib/github';
+import { Job, JobPermission } from 'projen/lib/github/workflows-model';
+
+export function addMergeJob(project: Project, baseBranch: string) {
+  const mergeJob: Job = {
+    runsOn: ['ubuntu-latest'],
+    permissions: {
+      pullRequests: JobPermission.WRITE,
+      contents: JobPermission.WRITE,
+    },
+    if: `contains(github.event.pull_request.labels.*.name, 'auto-merge') && github.base_ref == '${baseBranch}'`,
+    steps: [
+      {
+        run: 'gh pr merge --auto --merge "$PR_URL"',
+        env: {
+          PR_URL: '${{github.event.pull_request.html_url}}',
+          GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}',
+        },
+      },
+    ],
+  };
+
+  const github = GitHub.of(project);
+  if (!github) {
+    throw new Error(
+      'Auto merge is currently only supported for GitHub projects',
+    );
+  }
+
+  const workflow = new GithubWorkflow(github, 'auto-merge');
+  workflow.on({
+    pullRequestTarget: {
+      types: [
+        'labeled',
+        'opened',
+        'synchronize',
+        'reopened',
+        'ready_for_review',
+      ],
+    },
+  });
+
+  workflow.addJobs({ automerge: mergeJob });
+}

--- a/test/hello.test.ts
+++ b/test/hello.test.ts
@@ -1,4 +1,0 @@
-
-test('hello', () => {
-  console.error('TODO: Implement tests');
-});

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,0 +1,20 @@
+import { synthSnapshot } from 'projen/lib/util/synth';
+import { GemeenteNijmegenCdkApp } from '../src';
+
+describe('NijmegenProject', () => {
+  test('Contains automerge workflow by default', () => {
+    const project = new GemeenteNijmegenCdkApp({ cdkVersion: '2.51.0', defaultReleaseBranch: 'main', name: 'test project' });
+
+    const snapshot = synthSnapshot(project)['.github/workflows/auto-merge.yml'];
+    expect(snapshot).toContain(
+      'if: contains(github.event.pull_request.labels.*.name, \'auto-merge\') && github.base_ref == \'acceptance\'',
+    );
+  });
+
+  test('Doesn\'t contain automerge workflow when option is set', () => {
+    const project = new GemeenteNijmegenCdkApp({ cdkVersion: '2.51.0', defaultReleaseBranch: 'main', name: 'test project', enableAutoMergeDependencies: false });
+
+    const snapshot = synthSnapshot(project);
+    expect(snapshot).not.toHaveProperty('.github/workflows/auto-merge.yml');
+  });
+});


### PR DESCRIPTION
Adds an automerge GH workflow to the project. This workflow depends on the automerge setting in Github to be on, and the upgrade workflow to have 'acceptance' as its base branch.

NB: To prevent unwanted automatic merges, branch protection should be on for acceptance, and to require succesful builds. Otherwise, unsuccesful dependency updates may merge to acceptance.

Fixes https://github.com/GemeenteNijmegen/devops/issues/178