### PR TITLE
fix: Better error message when creating TS lib fails

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -104,7 +104,7 @@ export function setDefaultValues<T extends CombinedProjectOptions>(options: T) :
 export function setDefaultValuesNpmPublish<T extends CombinedProjectOptions>(options: T) : T {
   // Set defaults for publishing to npm.js
   if (!options.repository) {
-    throw Error('Repository must be set to Github repo for succesfull NPM publishing');
+    console.warn('Repository must be set to Github repo for succesfull NPM publishing, add a `repository` key to your .projenrc file.');
   }
 
   options = {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -104,7 +104,7 @@ export function setDefaultValues<T extends CombinedProjectOptions>(options: T) :
 export function setDefaultValuesNpmPublish<T extends CombinedProjectOptions>(options: T) : T {
   // Set defaults for publishing to npm.js
   if (!options.repository) {
-    console.warn('Repository must be set to Github repo for succesfull NPM publishing, add a `repository` key to your .projenrc file.');
+    throw Error('Repository must be set to Github repo for succesfull NPM publishing. Add the `--repository` parameter when creating a new ts-lib project.');
   }
 
   options = {


### PR DESCRIPTION
When creating a new ts lib with `npx projen new --from @gemeentenijmegen/projen-project-type ts-lib` creation will fail because the repository key has not been set yet.

~~This changes the fatal error to a warning~~, informing the user but ~~allowing~~ providing a hint on how to allow the project creation to complete.
