### PR TITLE
feat: made makeFiles optional with makeSampleFiles flag default false

### DIFF
--- a/API.md
+++ b/API.md
@@ -6402,6 +6402,7 @@ const gemeenteNijmegenCdkAppOptions: GemeenteNijmegenCdkAppOptions = { ... }
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableRepositoryValidation">enableRepositoryValidation</a></code> | <code>boolean</code> | Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableCfnLintOnGithub">enableCfnLintOnGithub</a></code> | <code>boolean</code> | Enable cfn-lint in the github build workflow. |
+| <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.makeSampleFiles">makeSampleFiles</a></code> | <code>boolean</code> | Whether to create sample files. |
 
 ---
 
@@ -8920,6 +8921,21 @@ public readonly enableCfnLintOnGithub: boolean;
 - *Default:* true
 
 Enable cfn-lint in the github build workflow.
+
+---
+
+##### `makeSampleFiles`<sup>Optional</sup> <a name="makeSampleFiles" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.makeSampleFiles"></a>
+
+```typescript
+public readonly makeSampleFiles: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether to create sample files.
+
+Defaults to false to make sure older repos have unwanted files by default.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The following project types can be used:
 - `jsii-lib` a JSII application (published to NPM by default)
 - `ts-lib` a typescript project (published to NPM by default)
 
+Adding sample files to a cdk-app can be done with
+``` bash
+npx projen new --from @gemeentenijmegen/projen-project-type cdk-app --makeSampleFiles
+```
+
 ### For existing projects
 For instructions on how to start using the project type in existing projects there is the [setup guide](./SETUP.md). 
 Note: for switching back to the awscdk-app-ts projen project type also see the [setup guide](./SETUP.md).

--- a/src/project-cdk-app.ts
+++ b/src/project-cdk-app.ts
@@ -9,6 +9,14 @@ export interface GemeenteNijmegenCdkAppOptions extends AwsCdkTypeScriptAppOption
    * @default true
    */
   readonly enableCfnLintOnGithub?: boolean;
+
+
+  /**
+   * Whether to create sample files.
+   * Defaults to false to make sure older repos have unwanted files by default.
+   * @default false
+   */
+  readonly makeSampleFiles?: boolean;
 }
 
 /**
@@ -23,6 +31,9 @@ export class GemeenteNijmegenCdkApp extends AwsCdkTypeScriptApp {
   constructor(options: GemeenteNijmegenCdkAppOptions) {
 
     const enableCfnLintOnGithub = options.enableCfnLintOnGithub ?? true;
+
+    // default sample files flag (false by default)
+    const makeSampleFiles = options.makeSampleFiles ?? false;
 
     options = setDefaultValues(options);
     options = setupDefaultCdkOptions(options);
@@ -74,8 +85,10 @@ export class GemeenteNijmegenCdkApp extends AwsCdkTypeScriptApp {
      */
     super(options);
 
-    // Create sample files
-    new GemeenteNijmegenSampleFiles(this);
+    // Conditionally create sample files only if makeSampleFiles is true.
+    if (makeSampleFiles) {
+      new GemeenteNijmegenSampleFiles(this);
+    }
 
 
     // Setup dependencies that must be included

--- a/src/sample/test/sample.test.ts
+++ b/src/sample/test/sample.test.ts
@@ -12,6 +12,7 @@ describe('GemeenteNijmegenCdkApp tests', () => {
     cdkVersion: '2.10.0',
     defaultReleaseBranch: 'main',
     name: 'TestProjectV1',
+    makeSampleFiles: true,
   });
   const snapshot = synthSnapshot(project);
 


### PR DESCRIPTION
I added screenshots of the local test to the pull request in slack

To ensure existing repos do not get unwanted files, the --makeSampleFiles flag was added
npx projen new --from file:../modules-projen/dist/js/package cdk-app does not create all the extra files
npx projen new --from file:../modules-projen/dist/js/package cdk-app --makeSampleFiles will

