### PR TITLE
chore: nvmNodeVersion default .nvmrc and pre-compile command

### DIFF
--- a/API.md
+++ b/API.md
@@ -6453,6 +6453,7 @@ const gemeenteNijmegenCdkAppOptions: GemeenteNijmegenCdkAppOptions = { ... }
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableAutoMergeDependencies">enableAutoMergeDependencies</a></code> | <code>boolean</code> | Enable an additional workflow that auto-merges PR's with the 'auto-merge' label. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableRepositoryValidation">enableRepositoryValidation</a></code> | <code>boolean</code> | Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen. |
+| <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.nvmNodeVersion">nvmNodeVersion</a></code> | <code>string</code> | Set the node version for .nvmrc and codebuild pipelines. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableCfnLintOnGithub">enableCfnLintOnGithub</a></code> | <code>boolean</code> | Enable cfn-lint in the github build workflow. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.makeSampleFiles">makeSampleFiles</a></code> | <code>boolean</code> | Whether to create sample files. |
 
@@ -9081,6 +9082,18 @@ This includes emergency workflow, correct secrets, branch protection etc.
 
 ---
 
+##### `nvmNodeVersion`<sup>Optional</sup> <a name="nvmNodeVersion" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.nvmNodeVersion"></a>
+
+```typescript
+public readonly nvmNodeVersion: string;
+```
+
+- *Type:* string
+
+Set the node version for .nvmrc and codebuild pipelines.
+
+---
+
 ##### `enableCfnLintOnGithub`<sup>Optional</sup> <a name="enableCfnLintOnGithub" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkAppOptions.property.enableCfnLintOnGithub"></a>
 
 ```typescript
@@ -9313,6 +9326,7 @@ const gemeenteNijmegenCdkLibOptions: GemeenteNijmegenCdkLibOptions = { ... }
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkLibOptions.property.enableAutoMergeDependencies">enableAutoMergeDependencies</a></code> | <code>boolean</code> | Enable an additional workflow that auto-merges PR's with the 'auto-merge' label. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkLibOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkLibOptions.property.enableRepositoryValidation">enableRepositoryValidation</a></code> | <code>boolean</code> | Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen. |
+| <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkLibOptions.property.nvmNodeVersion">nvmNodeVersion</a></code> | <code>string</code> | Set the node version for .nvmrc and codebuild pipelines. |
 
 ---
 
@@ -12058,6 +12072,18 @@ This includes emergency workflow, correct secrets, branch protection etc.
 
 ---
 
+##### `nvmNodeVersion`<sup>Optional</sup> <a name="nvmNodeVersion" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenCdkLibOptions.property.nvmNodeVersion"></a>
+
+```typescript
+public readonly nvmNodeVersion: string;
+```
+
+- *Type:* string
+
+Set the node version for .nvmrc and codebuild pipelines.
+
+---
+
 ### GemeenteNijmegenJsiiOptions <a name="GemeenteNijmegenJsiiOptions" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions"></a>
 
 #### Initializer <a name="Initializer" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions.Initializer"></a>
@@ -12246,6 +12272,7 @@ const gemeenteNijmegenJsiiOptions: GemeenteNijmegenJsiiOptions = { ... }
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions.property.enableAutoMergeDependencies">enableAutoMergeDependencies</a></code> | <code>boolean</code> | Enable an additional workflow that auto-merges PR's with the 'auto-merge' label. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions.property.enableRepositoryValidation">enableRepositoryValidation</a></code> | <code>boolean</code> | Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen. |
+| <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions.property.nvmNodeVersion">nvmNodeVersion</a></code> | <code>string</code> | Set the node version for .nvmrc and codebuild pipelines. |
 
 ---
 
@@ -14747,6 +14774,18 @@ This includes emergency workflow, correct secrets, branch protection etc.
 
 ---
 
+##### `nvmNodeVersion`<sup>Optional</sup> <a name="nvmNodeVersion" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenJsiiOptions.property.nvmNodeVersion"></a>
+
+```typescript
+public readonly nvmNodeVersion: string;
+```
+
+- *Type:* string
+
+Set the node version for .nvmrc and codebuild pipelines.
+
+---
+
 ### GemeenteNijmegenOptions <a name="GemeenteNijmegenOptions" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions"></a>
 
 #### Initializer <a name="Initializer" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions.Initializer"></a>
@@ -14764,6 +14803,7 @@ const gemeenteNijmegenOptions: GemeenteNijmegenOptions = { ... }
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions.property.enableAutoMergeDependencies">enableAutoMergeDependencies</a></code> | <code>boolean</code> | Enable an additional workflow that auto-merges PR's with the 'auto-merge' label. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions.property.enableRepositoryValidation">enableRepositoryValidation</a></code> | <code>boolean</code> | Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen. |
+| <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions.property.nvmNodeVersion">nvmNodeVersion</a></code> | <code>string</code> | Set the node version for .nvmrc and codebuild pipelines. |
 
 ---
 
@@ -14807,6 +14847,18 @@ public readonly enableRepositoryValidation: boolean;
 Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen.
 
 This includes emergency workflow, correct secrets, branch protection etc.
+
+---
+
+##### `nvmNodeVersion`<sup>Optional</sup> <a name="nvmNodeVersion" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenOptions.property.nvmNodeVersion"></a>
+
+```typescript
+public readonly nvmNodeVersion: string;
+```
+
+- *Type:* string
+
+Set the node version for .nvmrc and codebuild pipelines.
 
 ---
 
@@ -14982,6 +15034,7 @@ const gemeenteNijmegenTsPackageOptions: GemeenteNijmegenTsPackageOptions = { ...
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenTsPackageOptions.property.enableAutoMergeDependencies">enableAutoMergeDependencies</a></code> | <code>boolean</code> | Enable an additional workflow that auto-merges PR's with the 'auto-merge' label. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenTsPackageOptions.property.enableEmergencyProcedure">enableEmergencyProcedure</a></code> | <code>boolean</code> | Enable an additional workflow that allows branch protection bypass and will inform the team trough slack. |
 | <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenTsPackageOptions.property.enableRepositoryValidation">enableRepositoryValidation</a></code> | <code>boolean</code> | Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen. |
+| <code><a href="#@gemeentenijmegen/projen-project-type.GemeenteNijmegenTsPackageOptions.property.nvmNodeVersion">nvmNodeVersion</a></code> | <code>string</code> | Set the node version for .nvmrc and codebuild pipelines. |
 
 ---
 
@@ -17261,6 +17314,18 @@ public readonly enableRepositoryValidation: boolean;
 Enable an additional workflow that checks if the Github repository is configured according to the desired configuration for Gemeente Nijmegen.
 
 This includes emergency workflow, correct secrets, branch protection etc.
+
+---
+
+##### `nvmNodeVersion`<sup>Optional</sup> <a name="nvmNodeVersion" id="@gemeentenijmegen/projen-project-type.GemeenteNijmegenTsPackageOptions.property.nvmNodeVersion"></a>
+
+```typescript
+public readonly nvmNodeVersion: string;
+```
+
+- *Type:* string
+
+Set the node version for .nvmrc and codebuild pipelines.
 
 ---
 

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,7 @@
+import { LambdaRuntime } from 'projen/lib/awscdk';
+
+export class Defaults {
+  static readonly DEFAULT_NODE_VERSION = '22';
+  static readonly DEFAULT_LAMBDA_RUNTIME = LambdaRuntime.NODEJS_24_X;
+  static readonly DEFAULT_LICENSE = 'EUPL-1.2';
+}

--- a/src/getNodeVersion.ts
+++ b/src/getNodeVersion.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+import { Defaults } from './defaults';
+
+export function getNodeVersion(): string {
+  try {
+    return readFileSync('.nvmrc', 'utf-8').trim();
+  } catch (error: any) {
+    if (error.code == 'ENOENT') {
+      console.warn(`No .nvmrc present, using default node version ${Defaults.DEFAULT_NODE_VERSION}`);
+      return Defaults.DEFAULT_NODE_VERSION;
+    } else {
+      throw error;
+    }
+  }
+
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
+export { getNodeVersion } from './getNodeVersion';
 export * from './project-cdk-app';
 export * from './project-cdk-lib';
 export * from './project-jsii-lib';
 export * from './project-ts-lib';
 export { GemeenteNijmegenOptions } from './shared';
+

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,7 +1,7 @@
 import { TextFile } from 'projen';
-import { LambdaRuntime } from 'projen/lib/awscdk';
 import { NodeProject, NodeProjectOptions, NpmAccess } from 'projen/lib/javascript';
 import combine from './combine';
+import { Defaults } from './defaults';
 import { EmergencyProcedure } from './emergeny';
 import { addMergeJob } from './mergejob';
 import { addRepositoryValidationJob } from './validation';
@@ -51,8 +51,8 @@ export function setDefaultValues<T extends CombinedProjectOptions>(options: T): 
    * Set default license
    */
   options = {
-    license: 'EUPL-1.2',
-    nvmNodeVersion: '22',
+    license: Defaults.DEFAULT_LICENSE,
+    nvmNodeVersion: Defaults.DEFAULT_NODE_VERSION,
     ...options,
   };
 
@@ -175,7 +175,7 @@ export function setupDefaultCdkOptions<T extends CombinedProjectOptions>(options
       'cli-telemetry': false,
     },
     lambdaOptions: {
-      runtime: LambdaRuntime.NODEJS_24_X,
+      runtime: Defaults.DEFAULT_LAMBDA_RUNTIME,
     },
     ...options,
   };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,3 +1,4 @@
+import { TextFile, TextFileOptions } from 'projen';
 import { LambdaRuntime } from 'projen/lib/awscdk';
 import { NodeProject, NodeProjectOptions, NpmAccess } from 'projen/lib/javascript';
 import combine from './combine';
@@ -31,6 +32,12 @@ export interface GemeenteNijmegenOptions {
    */
   readonly enableRepositoryValidation?: boolean;
 
+  /**
+   * Set the node version for .nvmrc and codebuild pipelines
+   */
+  readonly nvmNodeVersion?: string;
+
+
 }
 
 //type NpmPackageOptions = TypeScriptProjectOptions | AwsCdkConstructLibraryOptions | JsiiProjectOptions;
@@ -45,6 +52,7 @@ export function setDefaultValues<T extends CombinedProjectOptions>(options: T): 
    */
   options = {
     license: 'EUPL-1.2',
+    nvmNodeVersion: '22',
     ...options,
   };
 
@@ -147,6 +155,15 @@ export function setupSharedConfiguration(
   if (enableRepositoryValidation) {
     addRepositoryValidationJob(project, options);
   }
+
+  /**
+   * Make .nvmrc file based on default nodeVersion of projenrc overwritten nodeVersion
+   * Add nvm use to pre-compile task to alsways run nvm use
+   */
+  new TextFile(project, '.nvmrc', {
+    lines: [options.nvmNodeVersion],
+  } as TextFileOptions);
+  project.tasks.tryFind('pre-compile')?.reset('nvm use');
 }
 
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import { TextFile, TextFileOptions } from 'projen';
+import { TextFile } from 'projen';
 import { LambdaRuntime } from 'projen/lib/awscdk';
 import { NodeProject, NodeProjectOptions, NpmAccess } from 'projen/lib/javascript';
 import combine from './combine';
@@ -158,12 +158,10 @@ export function setupSharedConfiguration(
 
   /**
    * Make .nvmrc file based on default nodeVersion of projenrc overwritten nodeVersion
-   * Add nvm use to pre-compile task to alsways run nvm use
    */
   new TextFile(project, '.nvmrc', {
-    lines: [options.nvmNodeVersion],
-  } as TextFileOptions);
-  project.tasks.tryFind('pre-compile')?.reset('nvm use');
+    lines: [options.nvmNodeVersion!],
+  });
 }
 
 


### PR DESCRIPTION
[Fixes #](https://github.com/GemeenteNijmegen/devops/issues/1137)
- nvmNodeVersion as an option in all projen projects
- default nvmNodeVersion - right now 22
- make new .nvmrc file with default nodeVersion
- pre-compile script, which was unused, set to `nvm use` to make sure the build always runs nvm use and the correct version