### PR TITLE
chore: add unused var eslint rule to prevent unused imports

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -162,6 +162,15 @@ export function setupSharedConfiguration(
   new TextFile(project, '.nvmrc', {
     lines: [options.nvmNodeVersion!],
   });
+
+  /**
+   * Add global eslint rules
+   */
+  (project as any).eslint?.addRules({
+    // Note: you must disable the base rule as it can report incorrect errors
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
+  });
 }
 
 

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -46,6 +46,13 @@ describe('NijmegenProject Defaults', () => {
     defaults.forEach(d => expect(ignore).toContain(d));
   });
 
+  test('ESLint unused vars rules are set', () => {
+    const eslintrc = snapshot['.eslintrc.json'];
+    expect(eslintrc).toBeDefined();
+
+    expect(eslintrc.rules['no-unused-vars']).toEqual('off');
+    expect(eslintrc.rules['@typescript-eslint/no-unused-vars']).toEqual('error');
+  });
 });
 
 


### PR DESCRIPTION
This could potentially speed up pipelines.

This will speed up development as the import validation is run early (it looks like it is currently run by `tsc build` in the build step).

I've tested this config [here](https://github.com/GemeenteNijmegen/attestatie-registratie-component-infra/pull/5).

After this is merged, I'll generate a new project and run eslint to check if there are any unused vars to solve in this project.