### PR TITLE
feat: Add default dependency cooldown of 3

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -72,6 +72,7 @@ export function setDefaultValues<T extends CombinedProjectOptions>(options: T): 
         labels: upgradeLabels,
         branches: [acceptanceBranchName],
       },
+      cooldown: 3,
     },
     ...options,
   };


### PR DESCRIPTION
Adds a cooldown option to dependency updates, meaning only dependency
versions older than 3 days will be used for dependency updates. This
protects against supply chain attacks, which ususally are detected
soon after deployment.

See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
for an exploration of the topic.

Fixes #